### PR TITLE
Change instances of part.Modules.find to part.FindModuleImplementing

### DIFF
--- a/AntennaHelper/AHEditor.cs
+++ b/AntennaHelper/AHEditor.cs
@@ -455,7 +455,7 @@ namespace AntennaHelper
 			relayCombAntennaList = new List<ModuleDataTransmitter> ();
 
 			foreach (Part part in EditorLogic.fetch.ship.Parts) {
-				foreach (ModuleDataTransmitter antenna in part.Modules.GetModules<ModuleDataTransmitter> ()) {
+				foreach (ModuleDataTransmitter antenna in part.FindModulesImplementing<ModuleDataTransmitter> ()) {
 					directAntennaList.Add (antenna);
 					if (antenna.antennaCombinable) {
 						directCombAntennaList.Add (antenna);
@@ -486,11 +486,10 @@ namespace AntennaHelper
 
 		public void AntennaListAddItem (Part part)
 		{
-			if (part.Modules.Contains<ModuleDataTransmitter> ()) {
-				foreach (ModuleDataTransmitter antenna in part.Modules.GetModules<ModuleDataTransmitter> ()) {
+
+            foreach (ModuleDataTransmitter antenna in part.FindModulesImplementing<ModuleDataTransmitter> ()) {
 					AntennaListAddItem (antenna);
 				}
-			}
 		}
 
 		public void AntennaListRemoveItem (ModuleDataTransmitter antenna)
@@ -511,10 +510,8 @@ namespace AntennaHelper
 
 		public void AntennaListRemoveItem (Part part)
 		{
-			if (part.Modules.Contains<ModuleDataTransmitter> ()) {
-				foreach (ModuleDataTransmitter antenna in part.Modules.GetModules<ModuleDataTransmitter> ()) {
-					AntennaListRemoveItem (antenna);
-				}
+			foreach (ModuleDataTransmitter antenna in part.FindModulesImplementing<ModuleDataTransmitter> ()) {
+				AntennaListRemoveItem (antenna);
 			}
 		}
 		#endregion

--- a/AntennaHelper/AHFlight.cs
+++ b/AntennaHelper/AHFlight.cs
@@ -159,10 +159,10 @@ namespace AntennaHelper
 			deployableAntennas = new Dictionary<ModuleDeployableAntenna, bool> ();
 
 			foreach (Part part in vessel.Parts.FindAll (
-				p => (p.Modules.Contains<ModuleDataTransmitter> ()) && (p.Modules.Contains<ModuleDeployableAntenna> ())))
+				p => (p.HasModuleImplementing<ModuleDataTransmitter> ()) && (p.HasModuleImplementing<ModuleDeployableAntenna> ())))
 			{
 				bool extended = true;
-				ModuleDeployableAntenna deployable = part.Modules.GetModule<ModuleDeployableAntenna> ();
+				ModuleDeployableAntenna deployable = part.FindModuleImplementing<ModuleDeployableAntenna> ();
 
 				if (deployable.deployState != ModuleDeployablePart.DeployState.EXTENDED) {
 					extended = false;

--- a/AntennaHelper/AHShipList.cs
+++ b/AntennaHelper/AHShipList.cs
@@ -45,12 +45,13 @@ namespace AntennaHelper
 			listAntennaPart = new List<ModuleDataTransmitter> ();
 
 			foreach (AvailablePart aPart in PartLoader.LoadedPartsList) {
-				if (aPart.partPrefab.Modules.Contains<ModuleDataTransmitter> ()) {
-					ModuleDataTransmitter antenna = aPart.partPrefab.Modules.GetModule<ModuleDataTransmitter> ();
-					if (antenna.antennaType != AntennaType.INTERNAL) {
-						listAntennaPart.Add (antenna);
-					}
-				}
+                foreach (ModuleDataTransmitter antenna in aPart.partPrefab.FindModulesImplementing<ModuleDataTransmitter>())
+                {
+                    if (antenna.antennaType != AntennaType.INTERNAL)
+                    {
+                        listAntennaPart.Add(antenna);
+                    }
+                }
 			}
 			listAntennaPart.Sort (CompareAntenna);
 		}

--- a/AntennaHelper/AHUtil.cs
+++ b/AntennaHelper/AHUtil.cs
@@ -213,11 +213,11 @@ namespace AntennaHelper
 
 			if (v.parts.Count > 0) {
 				foreach (Part p in v.parts) {
-					if (p.Modules.Contains<ModuleDataTransmitter> ()) {
+					if (p.HasModuleImplementing<ModuleDataTransmitter> ()) {
 						// Check extendability
 						if (checkIfExtended) {
-							if (p.Modules.Contains<ModuleDeployableAntenna>()) {
-								ModuleDeployableAntenna antDep = p.Modules.GetModule<ModuleDeployableAntenna> ();
+							if (p.HasModuleImplementing<ModuleDeployableAntenna>()) {
+								ModuleDeployableAntenna antDep = p.FindModuleImplementing<ModuleDeployableAntenna> ();
 								if ((antDep.deployState != ModuleDeployablePart.DeployState.EXTENDED) 
 									&& (antDep.deployState != ModuleDeployablePart.DeployState.EXTENDING)) {
 									continue;
@@ -225,7 +225,7 @@ namespace AntennaHelper
 							}
 						}
 
-						ModuleDataTransmitter ant = p.Modules.GetModule<ModuleDataTransmitter> ();
+						ModuleDataTransmitter ant = p.FindModuleImplementing<ModuleDataTransmitter> ();
 
 						// Check if relay
 						if (onlyRelay) {
@@ -247,10 +247,10 @@ namespace AntennaHelper
 				// This is for the tracking station, as the active vessel isn't actually active
 				foreach (ProtoPartSnapshot p in v.protoVessel.protoPartSnapshots) {
 					
-					if (p.partPrefab.Modules.Contains<ModuleDataTransmitter> ()) {
+					if (p.partPrefab.HasModuleImplementing<ModuleDataTransmitter> ()) {
 						// Check extendability
 						if (checkIfExtended) {
-							if (p.partPrefab.Modules.Contains<ModuleDeployableAntenna>()) {
+							if (p.partPrefab.HasModuleImplementing<ModuleDeployableAntenna>()) {
 								string antDep = p.modules.Find (x => x.moduleName == "ModuleDeployableAntenna").moduleValues.GetValue ("deployState");
 								if ((antDep != "EXTENDED") 
 								    && (antDep != "EXTENDING")) {
@@ -259,7 +259,7 @@ namespace AntennaHelper
 							}
 						}
 
-						ModuleDataTransmitter ant = p.partPrefab.Modules.GetModule<ModuleDataTransmitter> ();
+						ModuleDataTransmitter ant = p.partPrefab.FindModuleImplementing<ModuleDataTransmitter> ();
 						// Check if relay
 						if (onlyRelay) {
 							if (ant.antennaType != AntennaType.RELAY) {


### PR DESCRIPTION
This will make it so that mods that extends ModuleDataTransmitter (such as Near Future Exploration) is supported by this mod.

I also changed to part.HasModuleImplementing instead of part.Modules.Contains to support derivatives better.

As for Near Future Exploration, this makes it possible to use this mod and see the base range of the antenna, it does NOT take into account the feeded antennae range (via dish feeding). This is something that probably should be done at some point, and I'll have to figure out to see if there is a way.