### PR TITLE
Fix antenna parts loading for kerbalEVA parts

### DIFF
--- a/AntennaHelper/AHShipList.cs
+++ b/AntennaHelper/AHShipList.cs
@@ -47,14 +47,21 @@ namespace AntennaHelper
 
             foreach (AvailablePart aPart in PartLoader.LoadedPartsList)
             {
-                if (aPart != null)
+                if (aPart != null && aPart.partPrefab != null)
                 {
-                    foreach (ModuleDataTransmitter antenna in aPart.partPrefab.FindModulesImplementing<ModuleDataTransmitter>())
+                    try
                     {
-                        if (antenna.antennaType != AntennaType.INTERNAL)
+                        foreach (ModuleDataTransmitter antenna in aPart.partPrefab.FindModulesImplementing<ModuleDataTransmitter>())
                         {
-                            listAntennaPart.Add(antenna);
+                            if (antenna.antennaType != AntennaType.INTERNAL)
+                            {
+                                listAntennaPart.Add(antenna);
+                            }
                         }
+                    }
+                    catch
+                    {
+                        Debug.LogWarning("[AH] Cannot load Antennas for part, skipping: " + aPart.name);
                     }
                 }
             }


### PR DESCRIPTION
After some debugging, I've found the problem to be in `kerbalEVAFuture` and `kerbalEVAfemaleFuture` parts, not really sure about their behavior, anyway EVA communications are not of interest for AntennaHelper since we are just looking for Antenna parts to be used in vessels. 

Proposed fix is to skip parts during loading if an exception is thrown (to prevent even future incompatibilities), while logging (as warning level) the failed part name so user reading/providing logs can identify the problematic mods faster.

Future work may dig deeper inside kerbalEVA parts and identify a more precise way to skip these two parts, while keeping exception handling mechanism to avoid breaking user experience.